### PR TITLE
Update WallEntry.php

### DIFF
--- a/widgets/WallEntry.php
+++ b/widgets/WallEntry.php
@@ -56,6 +56,6 @@ class WallEntry extends WallStreamModuleEntryWidget
      */
     protected function getTitle()
     {
-        return trim($this->model->question) === '' ? $this->model->getContentName() : $this->model->question;
+        return trim((string)$this->model->question) === '' ? $this->model->getContentName() : $this->model->question;
     }
 }


### PR DESCRIPTION
To avoid 
yii\base\ErrorException: trim(): Passing null to parameter #1 ($string) of type string is deprecated in
.../protected/modules/polls/widgets/WallEntry.php:59