### PR TITLE
Enh: Proper Guest Notice

### DIFF
--- a/widgets/views/_answer.php
+++ b/widgets/views/_answer.php
@@ -19,12 +19,11 @@ $voteText = Yii::t('PollsModule.base', '{n,plural,=1{# {htmlTagBegin}vote{htmlTa
     'htmlTagEnd' => '</span>',
 ]);
 
-$userlist = ''; // variable for users output
-$maxUser = 10; // limit for rendered users inside the tooltip
+$userlist = '';
+$maxUser = 10;
 if (!$poll->anonymous) {
     foreach ($answer->votes as $i => $vote) {
         /* @var $vote PollAnswerUser */
-        // if only one user likes check if exists more user as limited
         if ($i == $maxUser) {
             $userlist .= Yii::t('PollsModule.base', 'and {count} more vote for this.', ['{count}' => $voteCount - $maxUser]);
             break;
@@ -33,15 +32,20 @@ if (!$poll->anonymous) {
         }
     }
 }
+
+$isGuest = Yii::$app->user->isGuest;
 ?>
 <div class="row" style="margin:0">
-    <?php if (!$poll->hasUserVoted() && !$poll->closed) : ?>
+    <?php if (!$poll->hasUserVoted() && !$poll->closed && !$isGuest) : ?>
         <div class="col-xs-1" style="margin-top:6px;padding-left:0">
             <?php if ($poll->allow_multiple) : ?>
                 <?= Html::checkBox('answers[' . $answer->id . ']'); ?>
             <?php else : ?>
                 <?= Html::radio('answers', false, ['value' => $answer->id, 'id' => 'answer_' . $answer->id]) ?>
             <?php endif; ?>
+        </div>
+    <?php elseif ($isGuest) : ?>
+        <div class="col-xs-1" style="margin-top:6px;padding-left:0">
         </div>
     <?php endif; ?>
 
@@ -54,7 +58,7 @@ if (!$poll->anonymous) {
 
     <?php if ($poll->isShowResult()) : ?>
         <div class="col-xs-2 text-nowrap tt" style="margin-top:14px;padding:0" data-toggle="tooltip" data-placement="top" data-original-title="<?= $userlist ?>">
-            <?= !$poll->anonymous && $voteCount
+            <?= !$poll->anonymous && $voteCount && !$isGuest
                 ? Link::asLink($voteText, $contentContainer->createUrl('/polls/poll/user-list-results', [
                     'pollId' => $poll->id,
                     'answerId' => $answer->id,

--- a/widgets/views/entry.php
+++ b/widgets/views/entry.php
@@ -47,7 +47,7 @@ humhub\modules\polls\assets\PollsAsset::register($this);
     <?php endif; ?>
 
     <?php if (Yii::$app->user->isGuest && !$poll->closed) : ?>
-        <?= Html::a(Yii::t('PollsModule.base', 'Vote'), Yii::$app->user->loginUrl, ['class' => 'btn btn-primary', 'data-target' => '#globalModal']); ?>
+        <?= Html::a(Yii::t('PollsModule.base', 'Login to vote'), Yii::$app->user->loginUrl, ['class' => 'btn btn-primary', 'data-target' => '#globalModal']); ?>
     <?php endif; ?>
 
 


### PR DESCRIPTION
I think currently it is very confusing to guests visiting a HumHub instance that uses the polls module and see the ability to use the checkboxes along side a vote button, this makes them think that they are allowed to vote but instead are opening the login modal without proper notice. I believe we should use something like this P/R to properly notify guests that it is for logging in not to vote on the poll.

### Logged In
![Screenshot_1](https://github.com/user-attachments/assets/f4779334-0697-4987-af77-cf52f263a472)
### Guest
![Screenshot_2](https://github.com/user-attachments/assets/89c3ed43-22c6-48f8-b51e-adeb8e8c8776)
